### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ FROM openjdk:17-alpine as deployer
 COPY --from=builder /src/target/*.jar /src/target/bankapp.jar
 
 # Expose application port 
-EXPOSE 8080
+EXPOSE 8081
 
 # Start the application
 ENTRYPOINT ["java", "-jar", "/src/target/bankapp.jar"]


### PR DESCRIPTION
port number change for running on Jenkins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the application to use port 8081 instead of 8080 for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->